### PR TITLE
else clause indentation and eval()

### DIFF
--- a/solutionreporttools/reporttools.py
+++ b/solutionreporttools/reporttools.py
@@ -114,8 +114,8 @@ def reportDataPrep(reportConfig):
                                 print "Finished executing model {0}".format(tool)
                             else:
                                 print "%s was not found, please verify the name" % tool
-                        else:
-                            print "%s was not found, please verify the path" % process["ToolPath"]
+                    else:
+                        print "%s was not found, please verify the path" % process["ToolPath"]
                 elif process["ToolType"].upper() == "SCRIPT":
                     for tool in process["Tools"]:
                         scriptPath = process["ToolPath"] + "/" + tool

--- a/solutionreporttools/reporttools.py
+++ b/solutionreporttools/reporttools.py
@@ -101,16 +101,13 @@ def reportDataPrep(reportConfig):
                 if process["ToolType"].upper() == "MODEL":
                     if arcpy.Exists(process["ToolPath"]):
                         arcpy.ImportToolbox(process["ToolPath"])
-                        arcpy.gp.toolbox = process["ToolPath"]
-                        tools = arcpy.ListTools()
+                        arcpy.gp.AddToolbox(process["ToolPath"])                                             
                         for tool in process["Tools"]:
-                            if tool in tools:
-                                customCode = "arcpy." + tool + "()"
-                                eval(customCode)
+                            if hasattr(arcpy, tool):
+                                getattr(arcpy, tool)()
                                 print "Finished executing model {0}".format(tool)
-                            elif tool + "_" + arcpy.gp.toolbox in tools:
-                                customCode = "arcpy." + tool + "_" + arcpy.gp.toolbox + "()"
-                                eval(customCode)
+                            elif hasattr(arcpy.gp, "{}_{}".format(tool, arcpy.gp.toolbox)):
+                                getattr(arcpy.gp, "{}_{}".format(tool, arcpy.gp.toolbox))()
                                 print "Finished executing model {0}".format(tool)
                             else:
                                 print "%s was not found, please verify the name" % tool


### PR DESCRIPTION
The current `else` clause was always executing after the [for loop](https://github.com/Esri/utilities-solution-data-automation/blob/8d49a6b033d61cc6a1c9fab8f47eeb12958c3a97/solutionreporttools/reporttools.py#L106-L118) when it should only execute if [`arcpy.Exists()`](https://github.com/Esri/utilities-solution-data-automation/blob/8d49a6b033d61cc6a1c9fab8f47eeb12958c3a97/solutionreporttools/reporttools.py#L102) is `False`.
[Coghlan's blog](http://python-notes.curiousefficiency.org/en/latest/python_concepts/break_else.html) for reference.